### PR TITLE
Fixed typo in latex_hack and rest_directive regex

### DIFF
--- a/wrap_plus.py
+++ b/wrap_plus.py
@@ -209,8 +209,8 @@ numbered_list = r'(?:(?:[0-9#]+[.)])+[\t ])'
 lettered_list = r'(?:[\w][.)][\t ])'
 bullet_list = r'(?:[*+#-]+[\t ])'
 list_pattern = re.compile(r'^[ \t]*' + OR(numbered_list, lettered_list, bullet_list) + r'[ \t]*')
-latex_hack = r'(:?\\)'
-rest_directive = r'(:?\.\.)'
+latex_hack = r'(?:\\)'
+rest_directive = r'(?:\.\.)'
 field_start = r'(?:[:@])'  # rest, javadoc, jsdoc, etc.
 new_paragraph_pattern = re.compile(r'^[\t ]*' +
     OR(numbered_list, lettered_list, bullet_list,


### PR DESCRIPTION
Corrected the regex pattern of capturing groups for latex_hack and rest_directive from `(:? )` to `(?: )`.